### PR TITLE
Use "become" instead of deprecated "sudo"

### DIFF
--- a/provisioning/roles/brew-cask/tasks/main.yml
+++ b/provisioning/roles/brew-cask/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: tap external homebrew_cask repositories
   homebrew_tap: tap=caskroom/cask state=present
-  sudo: false
+  become: false
 
 - name: update homebrew_cask
   homebrew: name=brew-cask state=latest
-  sudo: false
+  become: false
 
 - name: install and upgrade homebrew_cask packages
   homebrew_cask: >
@@ -13,4 +13,4 @@
     state={{ item.state | default('present') }}
   with_items: homebrew_cask_packages
   when: homebrew_cask_packages
-  sudo: false
+  become: false

--- a/provisioning/roles/brew/tasks/main.yml
+++ b/provisioning/roles/brew/tasks/main.yml
@@ -23,11 +23,11 @@
   homebrew_tap: tap={{ item }} state=present
   with_items: homebrew_repositories
   when: homebrew_repositories
-  sudo: False
+  become: False
 
 - name: update homebrew
   homebrew: update_homebrew=yes
-  sudo: False
+  become: False
 
 - name: install and upgrade homebrew packages
   homebrew:
@@ -36,4 +36,4 @@
     install_options={{ item.install_option | default('') }}
   with_items: homebrew_packages
   when: homebrew_packages
-  sudo: False
+  become: False

--- a/provisioning/site.yml
+++ b/provisioning/site.yml
@@ -1,7 +1,7 @@
 ---
 - name: OSX Local Provisioner
   hosts: local
-  sudo: no
+  become: no
   pre_tasks:
     - stat: path=~/.ssh
       register: ssh 


### PR DESCRIPTION
From ansible 1.9, "sudo" is deprecated.

See: http://docs.ansible.com/ansible/become.html